### PR TITLE
avoiding compiler optimizations

### DIFF
--- a/StringToIntBenchmark.cpp
+++ b/StringToIntBenchmark.cpp
@@ -17,7 +17,7 @@ static void BM_fast_atoi(benchmark::State& state){
   int a = 0;
   while (state.KeepRunning()){
     for (int i = 0; i < state.range(0); ++i){
-      a = fast_atoi(stringV[i].c_str());
+      benchmark::DoNotOptimize(a = fast_atoi(stringV[i].c_str()));
     }
   }
 }
@@ -29,7 +29,7 @@ static void BM_atoi(benchmark::State& state){
   int a = 0;
   while (state.KeepRunning()){
     for (int i = 0; i < state.range(0); ++i){
-      a = atoi(stringV[i].c_str());
+      benchmark::DoNotOptimize(a = atoi(stringV[i].c_str()));
     }
   }
 }
@@ -41,7 +41,7 @@ static void BM_stoi(benchmark::State& state){
   int a = 0;
   while (state.KeepRunning()){
     for (int i = 0; i < state.range(0); ++i){
-      a = stoi(stringV[i].c_str());
+      benchmark::DoNotOptimize(a = stoi(stringV[i].c_str()));
     }
   }
 }
@@ -54,7 +54,7 @@ static void BM_sstream(benchmark::State& state){
   while (state.KeepRunning()){
     for (int i = 0; i < state.range(0); ++i){
       istringstream ss(stringV[i]);
-      ss >> a;
+      benchmark::DoNotOptimize(ss >> a);
     }
   }
 }
@@ -66,7 +66,7 @@ static void BM_lexicalCast(benchmark::State& state){
   int a = 0;
   while (state.KeepRunning()){
     for (int i = 0; i < state.range(0); ++i){
-      a = boost::lexical_cast<int>(stringV[i]);
+      benchmark::DoNotOptimize(a = boost::lexical_cast<int>(stringV[i]));
     }
   }
 }
@@ -80,7 +80,7 @@ static void BM_qiParse(benchmark::State& state){
   int a = 0;
   while (state.KeepRunning()){
     for (int i = 0; i < state.range(0); ++i){
-      qi::parse(stringV[i].begin(), stringV[i].end(), int_, a);
+      benchmark::DoNotOptimize(qi::parse(stringV[i].begin(), stringV[i].end(), int_, a));
     }
   }
 } 

--- a/StringToIntBenchmark.cpp
+++ b/StringToIntBenchmark.cpp
@@ -41,7 +41,7 @@ static void BM_stoi(benchmark::State& state){
   int a = 0;
   while (state.KeepRunning()){
     for (int i = 0; i < state.range(0); ++i){
-      benchmark::DoNotOptimize(a = stoi(stringV[i].c_str()));
+      benchmark::DoNotOptimize(a = stoi(stringV[i]));
     }
   }
 }


### PR DESCRIPTION
2ns seemed a bit on the low side, the compiler actually removed the entire code - funny that clang/gcc were doing it for different functions!

That's the original code: there is no call to atoi/strtol, its an empty loop:
```
   0x00000000004119f0 <+0>:     push   rbx
   0x00000000004119f1 <+1>:     mov    rbx,rdi
   0x00000000004119f4 <+4>:     jmp    0x411a00 <BM_atoi(benchmark::State&)+16>
   0x00000000004119f6 <+6>:     mov    rdi,rbx
   0x00000000004119f9 <+9>:     call   0x413820 <benchmark::State::StartKeepRunning()>
   0x00000000004119fe <+14>:    jmp    0x411a08 <BM_atoi(benchmark::State&)+24>
   0x0000000000411a00 <+16>:    movzx  eax,BYTE PTR [rbx]
   0x0000000000411a03 <+19>:    cmp    eax,0x1
   0x0000000000411a06 <+22>:    jne    0x4119f6 <BM_atoi(benchmark::State&)+6>
   0x0000000000411a08 <+24>:    mov    rax,QWORD PTR [rbx+0x8]
   0x0000000000411a0c <+28>:    lea    rcx,[rax+0x1]
   0x0000000000411a10 <+32>:    mov    QWORD PTR [rbx+0x8],rcx
   0x0000000000411a14 <+36>:    cmp    rax,QWORD PTR [rbx+0x78]
   0x0000000000411a18 <+40>:    jb     0x411a00 <BM_atoi(benchmark::State&)+16>
   0x0000000000411a1a <+42>:    mov    rdi,rbx
   0x0000000000411a1d <+45>:    pop    rbx
   0x0000000000411a1e <+46>:    jmp    0x4138d0 <benchmark::State::FinishKeepRunning()>
```

Now it is calling it:
```
  0x00000000004119f0 <+0>:     push   r14
   0x00000000004119f2 <+2>:     push   rbx
   0x00000000004119f3 <+3>:     push   rax
   0x00000000004119f4 <+4>:     mov    r14,rdi
   0x00000000004119f7 <+7>:     jmp    0x411a50 <BM_atoi(benchmark::State&)+96>
   0x00000000004119f9 <+9>:     nop    DWORD PTR [rax+0x0]
   0x0000000000411a00 <+16>:    mov    rax,QWORD PTR [r14+0x10]
   0x0000000000411a04 <+20>:    cmp    DWORD PTR [rax],0x0
   0x0000000000411a07 <+23>:    mov    ebx,0x0
   0x0000000000411a0c <+28>:    jle    0x411a50 <BM_atoi(benchmark::State&)+96>
   0x0000000000411a0e <+30>:    xchg   ax,ax
   0x0000000000411a10 <+32>:    mov    rax,QWORD PTR [rip+0x23c629]        # 0x64e040 <stringV>
   0x0000000000411a17 <+39>:    mov    rdi,QWORD PTR [rax+rbx*8]
   0x0000000000411a1b <+43>:    xor    esi,esi
   0x0000000000411a1d <+45>:    mov    edx,0xa
   0x0000000000411a22 <+50>:    call   0x410330 <strtol@plt>     
   0x0000000000411a27 <+55>:    mov    DWORD PTR [rsp+0x4],eax
   0x0000000000411a2b <+59>:    inc    rbx
   0x0000000000411a2e <+62>:    mov    rax,QWORD PTR [r14+0x10]
   0x0000000000411a32 <+66>:    movsxd rax,DWORD PTR [rax]
   0x0000000000411a35 <+69>:    cmp    rbx,rax
   0x0000000000411a38 <+72>:    jl     0x411a10 <BM_atoi(benchmark::State&)+32>
   0x0000000000411a3a <+74>:    jmp    0x411a50 <BM_atoi(benchmark::State&)+96>
   0x0000000000411a3c <+76>:    mov    rdi,r14
   0x0000000000411a3f <+79>:    call   0x413890 <benchmark::State::StartKeepRunning()>
   0x0000000000411a44 <+84>:    jmp    0x411a59 <BM_atoi(benchmark::State&)+105>
   0x0000000000411a46 <+86>:    nop    WORD PTR cs:[rax+rax*1+0x0]
   0x0000000000411a50 <+96>:    movzx  eax,BYTE PTR [r14]
   0x0000000000411a54 <+100>:   cmp    eax,0x1
   0x0000000000411a57 <+103>:   jne    0x411a3c <BM_atoi(benchmark::State&)+76>
   0x0000000000411a59 <+105>:   mov    rax,QWORD PTR [r14+0x8]
   0x0000000000411a5d <+109>:   lea    rcx,[rax+0x1]
   0x0000000000411a61 <+113>:   mov    QWORD PTR [r14+0x8],rcx
   0x0000000000411a65 <+117>:   cmp    rax,QWORD PTR [r14+0x78]
   0x0000000000411a69 <+121>:   jb     0x411a00 <BM_atoi(benchmark::State&)+16>
   0x0000000000411a6b <+123>:   mov    rdi,r14
   0x0000000000411a6e <+126>:   add    rsp,0x8
   0x0000000000411a72 <+130>:   pop    rbx
   0x0000000000411a73 <+131>:   pop    r14
   0x0000000000411a75 <+133>:   jmp    0x413940 <benchmark::State::FinishKeepRunning()>
```

Last thing: `std::stoi` takes a `std::string` as arg and in the benchmark it was passing it as `.c_str()` which was building an additional `std::string`, which was probably taking way more time than the conversion itself!

Results seem much more coherent now - that's with clang 3.8, on my XPS15 ;)

```
--------------------------------------------------------
Benchmark                 Time           CPU Iterations
--------------------------------------------------------
BM_fast_atoi/7           53 ns         53 ns   14290423
BM_atoi/7               297 ns        297 ns    2355073
BM_stoi/7               302 ns        298 ns    2313689
BM_sstream/7           5000 ns       5005 ns     100000
BM_lexicalCast/7        387 ns        387 ns    1809465
BM_qiParse/7             71 ns         71 ns   10480077
```